### PR TITLE
Add error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ mio = "0.6.21"
 zmq = "0.9.2"
 futures = "0.3.4"
 slab = "0.4.2"
+thiserror = "1.0"
 once_cell = "1.3.1"
 tokio = { version = "0.2", features = ["io-driver"], optional = true }
 async-std = { version = "1.5", optional = true }

--- a/src/dealer.rs
+++ b/src/dealer.rs
@@ -22,12 +22,12 @@ use std::{
 use crate::{
     reactor::{AsRawSocket, ZmqSocket},
     socket::{Broker, MessageBuf, SocketBuilder},
-    Sink, Stream,
+    RecvError, SendError, Sink, SocketError, Stream,
 };
-use zmq::{Error, SocketType};
+use zmq::SocketType;
 
 /// Create a ZMQ socket with DEALER type
-pub fn dealer(endpoint: &str) -> Result<SocketBuilder<'_, Dealer>, zmq::Error> {
+pub fn dealer(endpoint: &str) -> Result<SocketBuilder<'_, Dealer>, SocketError> {
     Ok(SocketBuilder::new(SocketType::DEALER, endpoint))
 }
 
@@ -42,30 +42,37 @@ impl Dealer {
 }
 
 impl<T: Into<MessageBuf>> Sink<T> for Dealer {
-    type Error = Error;
+    type Error = SendError;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Sink::<T>::poll_ready(Pin::new(&mut self.get_mut().0), cx)
+            .map(|result| result.map_err(Into::into))
     }
 
     fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-        Pin::new(&mut self.get_mut().0).start_send(item)
+        Pin::new(&mut self.get_mut().0)
+            .start_send(item)
+            .map_err(Into::into)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Sink::<T>::poll_flush(Pin::new(&mut self.get_mut().0), cx)
+            .map(|result| result.map_err(Into::into))
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Sink::<T>::poll_close(Pin::new(&mut self.get_mut().0), cx)
+            .map(|result| result.map_err(Into::into))
     }
 }
 
 impl Stream for Dealer {
-    type Item = Result<MessageBuf, Error>;
+    type Item = Result<MessageBuf, RecvError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().0).poll_next(cx)
+        Pin::new(&mut self.get_mut().0)
+            .poll_next(cx)
+            .map(|poll| poll.map(|result| result.map_err(Into::into)))
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,379 @@
+//!
+//! # Errors
+//!
+//! We define a separate error type for three classes of operation:
+//!  * socket creation
+//!  * sending messages
+//!  * receiving messages
+//!
+//! We provide an error variant for each ØMQ error code that could occur for
+//! the given operation, excluding codes that are not relevant to the
+//! operation, are handled internally, or are not possible due to the design of
+//! this library.
+//!
+//! In each case we also provide a catch-all `Unexpected` variant. This variant
+//! indicates that an error code was produced by ØMQ which should not have been
+//! possible in the situation. Encountering this error variant should be
+//! considered a bug; in ØMQ itself, in its documentation or, most likely, in
+//! this crate.
+//!
+
+use thiserror::Error;
+
+/// The type of errors that can occur when creating a new ØMQ socket.
+#[derive(Clone, Copy, Debug, Error)]
+pub enum SocketError {
+    /// The requested socket type is invalid.
+    /// Corresponds to ØMQ error code `EINVAL`.
+    #[error("the requested socket type is invalid")]
+    InvalidSocketType,
+
+    /// The provided context is invalid.
+    /// Corresponds to ØMQ error code `EFAULT`.
+    #[error("the provided context is invalid")]
+    InvalidContext,
+
+    /// The limit on the total number of open ØMQ sockets has been reached.
+    /// Corresponds to ØMQ error code `EMFILE`.
+    #[error("the limit on the total number of open ØMQ sockets has been reached")]
+    SocketLimitReached,
+
+    /// The context specified was terminated.
+    /// Corresponds to ØMQ error code `ETERM`.
+    #[error("the context specified was terminated")]
+    ContextTerminated,
+
+    /// ØMQ produced an error variant that is not documented to occur when
+    /// creating a new socket. This should never happen and should be treated
+    /// as a bug.
+    #[error("an unexpected error occurred: {0}")]
+    Unexpected(#[source] zmq::Error),
+}
+
+impl SocketError {
+    fn to_zmq_error(self) -> zmq::Error {
+        match self {
+            SocketError::InvalidSocketType => zmq::Error::EINVAL,
+            SocketError::InvalidContext => zmq::Error::EFAULT,
+            SocketError::SocketLimitReached => zmq::Error::EMFILE,
+            SocketError::ContextTerminated => zmq::Error::ETERM,
+            SocketError::Unexpected(error) => error,
+        }
+    }
+}
+
+impl From<SocketError> for zmq::Error {
+    fn from(other: SocketError) -> Self {
+        other.to_zmq_error()
+    }
+}
+
+impl From<zmq::Error> for SocketError {
+    fn from(other: zmq::Error) -> Self {
+        match other {
+            zmq::Error::EINVAL => SocketError::InvalidSocketType,
+            zmq::Error::EFAULT => SocketError::InvalidContext,
+            zmq::Error::EMFILE => SocketError::SocketLimitReached,
+            zmq::Error::ETERM => SocketError::ContextTerminated,
+            error => SocketError::Unexpected(error),
+        }
+    }
+}
+
+/// The type of errors that can occur when sending a ØMQ message.
+///
+/// The following ØMQ error codes may occur in the underlying ØMQ implementation,
+/// but do not need to be handled by users of this crate:
+///
+///  * `EAGAIN` - this crate will automatically retry if this error code is
+///     produced
+///  * `ENOTSUP` - unsupported operations are prevented by the design of this
+///     crate
+///  * `EINVAL` - multipart messages are not yet supported
+///  * `ENOTSOCK` - the design of this crate prevents sending messages on an
+///     invalid socket
+///  * `EFSM` - this applies only to REP/REQ sockets which have their own error
+///     type
+#[derive(Clone, Copy, Debug, Error)]
+pub enum SendError {
+    /// The ØMQ context associated with the specified socket was terminated.
+    ///
+    /// Note that this error cannot occur unless you access the raw socket
+    /// using `as_raw_socket()`.
+    ///
+    /// Corresponds to ØMQ error code `ETERM`
+    #[error("the context specified was terminated")]
+    ContextTerminated,
+
+    /// The host is unreachable and the message cannot be routed.
+    ///
+    /// Corresponds to ØMQ error code `EHOSTUNREACH`.
+    #[error("the message cannot be routed")]
+    HostUnreachable,
+
+    /// The message is invalid.
+    ///
+    /// Corresponds to ØMQ error code `EFAULT`.
+    #[error("the message is invalid")]
+    InvalidMessage,
+
+    /// The operation was interrupted by delivery of a signal before the
+    /// message was sent.
+    ///
+    /// Corresponds to ØMQ error code `EINTR`.
+    /// TODO verify if this can actually occur, or if it can be handled
+    /// internally with a retry
+    #[error("the operation was interrupted by delivery of a signal before the message was sent")]
+    Interrupted,
+
+    /// ØMQ produced an error variant that is not documented to occur when
+    /// sending a message. This should never happen and should be treated as a
+    /// bug.
+    #[error("an unexpected error occurred: {0}")]
+    Unexpected(#[source] zmq::Error),
+}
+
+impl SendError {
+    fn to_zmq_error(self) -> zmq::Error {
+        match self {
+            SendError::ContextTerminated => zmq::Error::ETERM,
+            SendError::HostUnreachable => zmq::Error::EHOSTUNREACH,
+            SendError::InvalidMessage => zmq::Error::EFAULT,
+            SendError::Interrupted => zmq::Error::EINTR,
+            SendError::Unexpected(error) => error,
+        }
+    }
+}
+
+impl From<SendError> for zmq::Error {
+    fn from(other: SendError) -> Self {
+        other.to_zmq_error()
+    }
+}
+
+impl From<zmq::Error> for SendError {
+    fn from(other: zmq::Error) -> Self {
+        match other {
+            zmq::Error::ETERM => SendError::ContextTerminated,
+            zmq::Error::EHOSTUNREACH => SendError::HostUnreachable,
+            zmq::Error::EFAULT => SendError::InvalidMessage,
+            zmq::Error::EINTR => SendError::Interrupted,
+            error => SendError::Unexpected(error),
+        }
+    }
+}
+
+/// The type of errors that can occur when receiving a ØMQ message.
+///
+/// The following ØMQ error codes may occur in the underlying ØMQ implementation,
+/// but do not need to be handled by users of this crate:
+///
+///  * `EAGAIN` - this crate will automatically retry if this error code is
+///     produced
+///  * `ENOTSUP` - unsupported operations are prevented by the design of this
+///     crate
+///  * `EINVAL` - multipart messages are not yet supported
+///  * `ENOTSOCK` - the design of this crate prevents sending messages on an
+///     invalid socket
+///  * `EFSM` - this applies only to REP/REQ sockets which have their own error
+///     type
+#[derive(Clone, Copy, Debug, Error)]
+pub enum RecvError {
+    /// The ØMQ context associated with the specified socket was terminated.
+    ///
+    /// Note that this error cannot occur unless you access the raw socket
+    /// using `as_raw_socket()`.
+    ///
+    /// Corresponds to ØMQ error code `ETERM`
+    #[error("the context specified was terminated")]
+    ContextTerminated,
+
+    /// The operation was interrupted by delivery of a signal before the
+    /// message was received.
+    ///
+    /// Corresponds to ØMQ error code `EINTR`.
+    /// TODO verify if this can actually occur, or if it can be handled
+    /// internally
+    #[error(
+        "the operation was interrupted by delivery of a signal before the message was received"
+    )]
+    Interrupted,
+
+    /// ØMQ produced an error variant that is not documented to occur when
+    /// receiving a message. This should never happen and should be treated as
+    /// a bug.
+    #[error("an unexpected error occurred: {0}")]
+    Unexpected(#[source] zmq::Error),
+}
+
+impl RecvError {
+    fn to_zmq_error(self) -> zmq::Error {
+        match self {
+            RecvError::ContextTerminated => zmq::Error::ETERM,
+            RecvError::Interrupted => zmq::Error::EINTR,
+            RecvError::Unexpected(error) => error,
+        }
+    }
+}
+
+impl From<RecvError> for zmq::Error {
+    fn from(other: RecvError) -> Self {
+        other.to_zmq_error()
+    }
+}
+
+impl From<zmq::Error> for RecvError {
+    fn from(other: zmq::Error) -> Self {
+        match other {
+            zmq::Error::ETERM => RecvError::ContextTerminated,
+            zmq::Error::EINTR => RecvError::Interrupted,
+            error => RecvError::Unexpected(error),
+        }
+    }
+}
+
+/// The type of errors that can occur when sending on a request channel.
+///
+/// The following ØMQ error codes may occur in the underlying ØMQ implementation,
+/// but do not need to be handled by users of this crate:
+///
+///  * `EAGAIN` - this crate will automatically retry if this error code is
+///     produced
+///  * `ENOTSUP` - unsupported operations are prevented by the design of this
+///     crate
+///  * `EINVAL` - multipart messages are not yet supported
+///  * `ENOTSOCK` - the design of this crate prevents sending messages on an
+///     invalid socket
+#[derive(Clone, Copy, Debug, Error)]
+pub enum RequestReplyError {
+    /// The socket was in the incorrect state for the operation.
+    ///
+    /// This can occur when sending a message on a request or reply socket when
+    /// the socket is in a waiting state.
+    ///
+    /// Corresponds to ØMQ error code `EFSM`.
+    #[error("this socket cannot send when it is awaiting a reply")]
+    AwaitingReply,
+
+    /// The ØMQ context associated with the specified socket was terminated.
+    ///
+    /// Note that this error cannot occur unless you access the raw socket
+    /// using `as_raw_socket()`.
+    ///
+    /// Corresponds to ØMQ error code `ETERM`
+    #[error("the context specified was terminated")]
+    ContextTerminated,
+
+    /// The host is unreachable and the message cannot be routed.
+    ///
+    /// Corresponds to ØMQ error code `EHOSTUNREACH`.
+    #[error("the message cannot be routed")]
+    HostUnreachable,
+
+    /// The operation was interrupted by delivery of a signal before the
+    /// message was sent.
+    ///
+    /// Corresponds to ØMQ error code `EINTR`.
+    /// TODO verify if this can actually occur, or if it can be handled
+    /// internally with a retry
+    #[error("the operation was interrupted by delivery of a signal before the message was sent")]
+    Interrupted,
+
+    /// ØMQ produced an error variant that is not documented to occur when
+    /// sending a message. This should never happen and should be treated as a
+    /// bug.
+    #[error("an unexpected error occurred: {0}")]
+    Unexpected(#[source] zmq::Error),
+}
+
+impl RequestReplyError {
+    fn to_zmq_error(self) -> zmq::Error {
+        match self {
+            RequestReplyError::AwaitingReply => zmq::Error::EFSM,
+            RequestReplyError::ContextTerminated => zmq::Error::ETERM,
+            RequestReplyError::HostUnreachable => zmq::Error::EHOSTUNREACH,
+            RequestReplyError::Interrupted => zmq::Error::EINTR,
+            RequestReplyError::Unexpected(error) => error,
+        }
+    }
+}
+
+impl From<RequestReplyError> for zmq::Error {
+    fn from(other: RequestReplyError) -> Self {
+        other.to_zmq_error()
+    }
+}
+
+impl From<zmq::Error> for RequestReplyError {
+    fn from(other: zmq::Error) -> Self {
+        match other {
+            zmq::Error::EFSM => RequestReplyError::AwaitingReply,
+            zmq::Error::ETERM => RequestReplyError::ContextTerminated,
+            zmq::Error::EHOSTUNREACH => RequestReplyError::HostUnreachable,
+            zmq::Error::EINTR => RequestReplyError::Interrupted,
+            error => RequestReplyError::Unexpected(error),
+        }
+    }
+}
+
+/// The type of errors that can occur when setting or unsetting a subscription
+/// topic.
+///
+/// The following ØMQ error codes may occur in the underlying ØMQ implementation,
+/// but do not need to be handled by users of this crate:
+///
+///  * `EINVAL` - the option name is always correct
+///  * `ENOTSOCK` - the design of this crate prevents sending messages on an
+///     invalid socket
+#[derive(Clone, Copy, Debug, Error)]
+pub enum SubscribeError {
+    /// The ØMQ context associated with the specified socket was terminated.
+    ///
+    /// Note that this error cannot occur unless you access the raw socket
+    /// using `as_raw_socket()`.
+    ///
+    /// Corresponds to ØMQ error code `ETERM`
+    #[error("the context specified was terminated")]
+    ContextTerminated,
+
+    /// The operation was interrupted by delivery of a signal before the
+    /// message was sent.
+    ///
+    /// Corresponds to ØMQ error code `EINTR`.
+    /// TODO verify if this can actually occur, or if it can be handled
+    /// internally with a retry
+    #[error("the operation was interrupted by delivery of a signal before the message was sent")]
+    Interrupted,
+
+    /// ØMQ produced an error variant that is not documented to occur when
+    /// sending a message. This should never happen and should be treated as a
+    /// bug.
+    #[error("an unexpected error occurred: {0}")]
+    Unexpected(#[source] zmq::Error),
+}
+
+impl SubscribeError {
+    fn to_zmq_error(self) -> zmq::Error {
+        match self {
+            SubscribeError::ContextTerminated => zmq::Error::ETERM,
+            SubscribeError::Interrupted => zmq::Error::EINTR,
+            SubscribeError::Unexpected(error) => error,
+        }
+    }
+}
+
+impl From<SubscribeError> for zmq::Error {
+    fn from(other: SubscribeError) -> Self {
+        other.to_zmq_error()
+    }
+}
+
+impl From<zmq::Error> for SubscribeError {
+    fn from(other: zmq::Error) -> Self {
+        match other {
+            zmq::Error::ETERM => SubscribeError::ContextTerminated,
+            zmq::Error::EINTR => SubscribeError::Interrupted,
+            error => SubscribeError::Unexpected(error),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,7 @@
 //! Prelude module provides some common types, traits and their methods. This crate also re-export
 //! so it can be easier for you to import them.
 //!
-//! Another common issue when people adopting a library is to deal with its error handling flow.
-//! To prevent introducing more overhead, `async_zmq` uses the exact same [`Result`]/[`Error`] type
-//! in [`zmq`] crate and re-export them.
-//!
 //! [`Result`]: prelude/type.Result.html
-//! [`Error`]: prelude/type.Error.html
 //! [`zmq`]: https://crates.io/crates/zmq
 //! [`async-std`]: https://crates.io/crates/async-std
 
@@ -49,6 +44,7 @@
 #![warn(missing_docs, rust_2018_idioms, unreachable_pub)]
 
 pub mod dealer;
+pub mod errors;
 pub mod pair;
 pub mod publish;
 pub mod pull;
@@ -67,10 +63,12 @@ mod socket;
 /// The prelude re-exports most commonly used traits and macros from this crate.
 pub mod prelude {
     pub use crate::dealer::{dealer, Dealer};
+    pub use crate::errors::*;
     pub use crate::pair::{pair, Pair};
     pub use crate::publish::{publish, Publish};
     pub use crate::pull::{pull, Pull};
     pub use crate::push::{push, Push};
+    pub use crate::reactor::AsRawSocket;
     pub use crate::reply::{reply, Reply};
     pub use crate::request::{request, Request};
     pub use crate::socket::{MessageBuf, SocketBuilder};
@@ -80,8 +78,7 @@ pub mod prelude {
     pub use crate::xsubscribe::{xsubscribe, XSubscribe};
     pub use futures::sink::{Sink, SinkExt};
     pub use futures::stream::{Stream, StreamExt};
-    pub use zmq::{self, Error, Message, Result, Context};
-    pub use crate::reactor::AsRawSocket;
+    pub use zmq::{self, Context, Error, Message, Result};
 }
 
 pub use prelude::*;

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -28,16 +28,16 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use zmq::{Error, SocketType};
+use zmq::SocketType;
 
 use crate::{
     reactor::{AsRawSocket, ZmqSocket},
     socket::{MessageBuf, Reciever, SocketBuilder},
-    Stream,
+    RecvError, SocketError, Stream,
 };
 
 /// Create a ZMQ socket with PULL type
-pub fn pull(endpoint: &str) -> Result<SocketBuilder<'_, Pull>, zmq::Error> {
+pub fn pull(endpoint: &str) -> Result<SocketBuilder<'_, Pull>, SocketError> {
     Ok(SocketBuilder::new(SocketType::PULL, endpoint))
 }
 
@@ -60,9 +60,11 @@ impl From<zmq::Socket> for Pull {
 }
 
 impl Stream for Pull {
-    type Item = Result<MessageBuf, Error>;
+    type Item = Result<MessageBuf, RecvError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().0).poll_next(cx)
+        Pin::new(&mut self.get_mut().0)
+            .poll_next(cx)
+            .map(|poll| poll.map(|result| result.map_err(Into::into)))
     }
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -23,16 +23,16 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use zmq::{Error, SocketType};
+use zmq::SocketType;
 
 use crate::{
     reactor::{AsRawSocket, ZmqSocket},
     socket::{MessageBuf, Sender, SocketBuilder},
-    Sink,
+    SendError, Sink, SocketError,
 };
 
 /// Create a ZMQ socket with PUSH type
-pub fn push(endpoint: &str) -> Result<SocketBuilder<'_, Push>, zmq::Error> {
+pub fn push(endpoint: &str) -> Result<SocketBuilder<'_, Push>, SocketError> {
     Ok(SocketBuilder::new(SocketType::PUSH, endpoint))
 }
 
@@ -47,22 +47,27 @@ impl Push {
 }
 
 impl<T: Into<MessageBuf>> Sink<T> for Push {
-    type Error = Error;
+    type Error = SendError;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Sink::<T>::poll_ready(Pin::new(&mut self.get_mut().0), cx)
+            .map(|result| result.map_err(Into::into))
     }
 
     fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-        Pin::new(&mut self.get_mut().0).start_send(item)
+        Pin::new(&mut self.get_mut().0)
+            .start_send(item)
+            .map_err(Into::into)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Sink::<T>::poll_flush(Pin::new(&mut self.get_mut().0), cx)
+            .map(|result| result.map_err(Into::into))
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Sink::<T>::poll_close(Pin::new(&mut self.get_mut().0), cx)
+            .map(|result| result.map_err(Into::into))
     }
 }
 

--- a/src/reactor/async_std_zmq/mod.rs
+++ b/src/reactor/async_std_zmq/mod.rs
@@ -23,7 +23,11 @@ impl ZmqSocket {
         }
     }
 
-    pub(crate) fn send(&self, cx: &mut Context<'_>, buffer: &mut MessageBuf) -> Poll<Result<(), Error>> {
+    pub(crate) fn send(
+        &self,
+        cx: &mut Context<'_>,
+        buffer: &mut MessageBuf,
+    ) -> Poll<Result<(), Error>> {
         ready!(self.poll_write_ready(cx));
         ready!(self.poll_event(zmq::POLLOUT))?;
 

--- a/src/reactor/tokio_zmq/mod.rs
+++ b/src/reactor/tokio_zmq/mod.rs
@@ -1,10 +1,7 @@
 //! Socket type registered in tokio reactor
 
 use crate::{
-    reactor::{
-        evented,
-        AsRawSocket,
-    },
+    reactor::{evented, AsRawSocket},
     socket::MessageBuf,
 };
 
@@ -35,7 +32,11 @@ impl ZmqSocket {
         }
     }
 
-    pub(crate) fn send(&self, cx: &mut Context<'_>, buffer: &mut MessageBuf) -> Poll<Result<(), Error>> {
+    pub(crate) fn send(
+        &self,
+        cx: &mut Context<'_>,
+        buffer: &mut MessageBuf,
+    ) -> Poll<Result<(), Error>> {
         futures::ready!(self.evented.poll_write_ready(cx));
         futures::ready!(self.poll_event(zmq::POLLOUT))?;
 

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -25,17 +25,18 @@ use std::{
     task::{Context, Poll},
 };
 
-use zmq::{Error, SocketType};
+use zmq::SocketType;
 
 use crate::{
     reactor::{AsRawSocket, ZmqSocket},
     socket::{MessageBuf, Sender, SocketBuilder},
+    RecvError, RequestReplyError, SocketError,
 };
 
 use futures::{future::poll_fn, Stream};
 
 /// Create a ZMQ socket with REP type
-pub fn reply(endpoint: &str) -> Result<SocketBuilder<'_, Reply>, zmq::Error> {
+pub fn reply(endpoint: &str) -> Result<SocketBuilder<'_, Reply>, SocketError> {
     Ok(SocketBuilder::new(SocketType::REP, endpoint))
 }
 
@@ -60,14 +61,14 @@ impl From<zmq::Socket> for Reply {
 impl Reply {
     /// Receive request from REQ/DEALER socket. This should be the first method to be called, and then
     /// continue with receive/send pattern in synchronous way.
-    pub async fn recv(&self) -> Result<MessageBuf, Error> {
+    pub async fn recv(&self) -> Result<MessageBuf, RequestReplyError> {
         let msg = poll_fn(|cx| self.inner.socket.recv(cx)).await?;
         self.received.store(true, Ordering::Relaxed);
         Ok(msg)
     }
 
     /// Send reply to REQ/DEALER socket. [`recv`](#method.recv) must be called first in order to reply.
-    pub async fn send<T: Into<MessageBuf>>(&self, msg: T) -> Result<(), Error> {
+    pub async fn send<T: Into<MessageBuf>>(&self, msg: T) -> Result<(), RequestReplyError> {
         let mut msg = msg.into();
         let res = poll_fn(move |cx| self.inner.socket.send(cx, &mut msg)).await?;
         self.received.store(false, Ordering::Relaxed);
@@ -81,7 +82,7 @@ impl Reply {
 }
 
 impl Stream for Reply {
-    type Item = Result<MessageBuf, Error>;
+    type Item = Result<MessageBuf, RecvError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(Some(Ok(futures::ready!(self.inner.socket.recv(cx))?)))

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -3,10 +3,7 @@ use std::convert::Into;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::{
-    reactor::ZmqSocket,
-    Message, Sink, Stream,
-};
+use crate::{reactor::ZmqSocket, Message, Sink, Stream};
 use futures::ready;
 use zmq::Error;
 

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -32,16 +32,16 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use zmq::{Error, SocketType};
+use zmq::SocketType;
 
 use crate::{
     reactor::{AsRawSocket, ZmqSocket},
     socket::{MessageBuf, Reciever, SocketBuilder},
-    Stream,
+    RecvError, SocketError, Stream, SubscribeError,
 };
 
 /// Create a ZMQ socket with SUB type
-pub fn subscribe(endpoint: &str) -> Result<SocketBuilder<'_, Subscribe>, zmq::Error> {
+pub fn subscribe(endpoint: &str) -> Result<SocketBuilder<'_, Subscribe>, SocketError> {
     Ok(SocketBuilder::new(SocketType::SUB, endpoint))
 }
 
@@ -57,22 +57,24 @@ impl From<zmq::Socket> for Subscribe {
 }
 
 impl Stream for Subscribe {
-    type Item = Result<MessageBuf, Error>;
+    type Item = Result<MessageBuf, RecvError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().0).poll_next(cx)
+        Pin::new(&mut self.get_mut().0)
+            .poll_next(cx)
+            .map(|poll| poll.map(|result| result.map_err(Into::into)))
     }
 }
 
 impl Subscribe {
     /// Subscribe a topic to the socket
-    pub fn set_subscribe(&self, topic: &str) -> Result<(), zmq::Error> {
-        self.as_raw_socket().set_subscribe(topic.as_bytes())
+    pub fn set_subscribe(&self, topic: &str) -> Result<(), SubscribeError> {
+        Ok(self.as_raw_socket().set_subscribe(topic.as_bytes())?)
     }
 
     /// Remove a topic from the socket
-    pub fn set_unsubscribe(&self, topic: &str) -> Result<(), zmq::Error> {
-        self.as_raw_socket().set_unsubscribe(topic.as_bytes())
+    pub fn set_unsubscribe(&self, topic: &str) -> Result<(), SubscribeError> {
+        Ok(self.as_raw_socket().set_unsubscribe(topic.as_bytes())?)
     }
 
     /// Represent as `Socket` from zmq crate in case you want to call its methods.

--- a/src/xsubscribe.rs
+++ b/src/xsubscribe.rs
@@ -32,16 +32,16 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use zmq::{Error, SocketType};
+use zmq::SocketType;
 
 use crate::{
     reactor::{AsRawSocket, ZmqSocket},
     socket::{MessageBuf, Reciever, SocketBuilder},
-    Stream,
+    RecvError, SocketError, Stream, SubscribeError,
 };
 
 /// Create a ZMQ socket with XSUB type
-pub fn xsubscribe(endpoint: &str) -> Result<SocketBuilder<'_, XSubscribe>, zmq::Error> {
+pub fn xsubscribe(endpoint: &str) -> Result<SocketBuilder<'_, XSubscribe>, SocketError> {
     Ok(SocketBuilder::new(SocketType::XSUB, endpoint))
 }
 
@@ -57,22 +57,24 @@ impl From<zmq::Socket> for XSubscribe {
 }
 
 impl Stream for XSubscribe {
-    type Item = Result<MessageBuf, Error>;
+    type Item = Result<MessageBuf, RecvError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().0).poll_next(cx)
+        Pin::new(&mut self.get_mut().0)
+            .poll_next(cx)
+            .map(|poll| poll.map(|result| result.map_err(Into::into)))
     }
 }
 
 impl XSubscribe {
     /// Subscribe a topic to the socket
-    pub fn set_subscribe(&self, topic: &str) -> Result<(), zmq::Error> {
-        self.as_raw_socket().set_subscribe(topic.as_bytes())
+    pub fn set_subscribe(&self, topic: &str) -> Result<(), SubscribeError> {
+        Ok(self.as_raw_socket().set_subscribe(topic.as_bytes())?)
     }
 
     /// Remove a topic from the socket
-    pub fn set_unsubscribe(&self, topic: &str) -> Result<(), zmq::Error> {
-        self.as_raw_socket().set_unsubscribe(topic.as_bytes())
+    pub fn set_unsubscribe(&self, topic: &str) -> Result<(), SubscribeError> {
+        Ok(self.as_raw_socket().set_unsubscribe(topic.as_bytes())?)
     }
 
     /// Represent as `Socket` from zmq crate in case you want to call its methods.

--- a/tests/xpub.rs
+++ b/tests/xpub.rs
@@ -1,4 +1,4 @@
-use async_zmq::{xpublish, subscribe, Result, StreamExt, Context};
+use async_zmq::{subscribe, xpublish, Context, Result, StreamExt};
 
 #[async_std::test]
 async fn xpublish_subscribe() -> Result<()> {


### PR DESCRIPTION
Internals still use `zmq::Error`. Due to the nature of code re-use, it makes sense to just convert the error in the public layer of the API.

`RequestReplyError` is needed because REQ/REP sockets can be in the wrong state when sending, which adds an extra error variant (`EFSM`). However, this could be removed if the design of the REQ/REP socket types were changed to statically enforce this. For example by having send and recv consume self and return the complementary type.

I have included `InvalidContext` (`EFAULT`), but it can likely be removed if the crate can guarantee that the context is always valid in safe code. Possibly the same for `ContextTerminated` (`ETERM`). If these are both removed then `set_subscribe` essentially becomes infallible and we can get rid of `SubscribeError` too.

As mentioned in some comments, the `Interrupted` (`EINTR`) variant may not be necessary at all. It's not clear to me that ZMQ ever handles an interrupt like this in practice. But I am prepared to be wrong on that point! If interrupts can be handled, the type of interrupt is not communicated, so recovery by retrying might not be possible.

Resolve #1 