### PR TITLE
Retry on EAGAIN, instead of returning an error

### DIFF
--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -22,7 +22,7 @@ impl ZmqSocket {
         if self.as_socket().get_events()?.contains(event) {
             Poll::Ready(Ok(()))
         } else {
-            Poll::Ready(Err(Error::EAGAIN))
+            Poll::Pending
         }
     }
 


### PR DESCRIPTION
The EAGAIN error shouldn't be visible to the user.


However, I think something else is broken here. When I got to this error, it was after receiving data which _should_ have been ready.

The Tokio reactor doesn't have the same problem, but it is dealt with in (what I think is) a hacky way: by polling the ZMQ socket directly:

```
        match self.as_socket().poll(event, 100) {
            Ok(_) => {}
            Err(zmq::Error::EAGAIN) => return Poll::Pending,
            Err(e) => return Poll::Ready(Err(e)),
        };
```

I don't think this is right. If `poll_event` is called erroneously (and it will be), it will block unnecessarily for 100ms.