### PR TITLE
Added feature forwarding to vendor the zmq native code build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ slab = "0.4.2"
 thiserror = "1.0"
 once_cell = "1.3.1"
 
+[features]
+vendored = ["zmq/vendored"]
+
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
 async-std = { version = "1.5", features = ["attributes"] }


### PR DESCRIPTION
I've added a feature forwarding here to have the `zmq` crate to a vendored build for native code.  Tested by cross-compiling for armhf and it's working for me.