### PR TITLE
Switch github action to cargo check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,10 @@ jobs:
     - name: Install ZeroMQ
       run: sudo apt update && sudo apt install -y --no-install-recommends libzmq3-dev
 
-    - name: cargo build
+    - name: cargo check
       uses: actions-rs/cargo@v1
       with:
-        command: build
+        command: check
 
     - name: cargo test
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
We're currently using `cargo build` to check if the code compiles. `cargo check` is faster and sufficient for this
